### PR TITLE
fix inter.dist.calc function

### DIFF
--- a/code/Prunus IBM v1.R
+++ b/code/Prunus IBM v1.R
@@ -418,7 +418,7 @@ intra.dist.calc <- function(trees, r=sqrt(1600/pi)){
 # almost same as above, except only for adult trees, and more spatially sensitive
 inter.dist.calc <- function(trees.hetero, trees.con, r=sqrt(1600/pi)){
   # calc distance
-  dists <- spDists(trees.hetero, trees.con)
+  dists <- spDists(as.matrix(trees.hetero), as.matrix(trees.con))
   dbh <- exp(trees.hetero$logdbh)
   # diagonal elements and trees which are > sqrt(400/pi) m from focal should not be computed (note: 1600m2 is the area of a 40x40m plot)
   # to get rid simply set to a very large value


### PR DESCRIPTION
I converted tree data to matrices to prevent spDists from calling spDists N1 incorrectly (otherwise it throws error about dimension mismatch). Can you check if the output is what you wanted originally? Not sure why I didn't see this error last time, could be related to code update in the `sp` package...